### PR TITLE
replaced IntegerGreaterThan with Integer.IsGreater

### DIFF
--- a/resources/skins/Default/720p/script-videoextras-main.xml
+++ b/resources/skins/Default/720p/script-videoextras-main.xml
@@ -169,7 +169,7 @@
 						<height>20</height>
 						<!-- Default XBMC Icon -->
 						<texture>OverlayWatched.png</texture>
-						<visible>IntegerGreaterThan(ListItem.PlayCount,0)</visible>
+						<visible>Integer.IsGreater(ListItem.PlayCount,0)</visible>
 					</control>
 				</itemlayout>
 				<focusedlayout height="40" width="1080">
@@ -221,7 +221,7 @@
 						<height>20</height>
 						<!-- Default XBMC Icon -->
 						<texture>OverlayWatched.png</texture>
-						<visible>IntegerGreaterThan(ListItem.PlayCount,0)</visible>
+						<visible>Integer.IsGreater(ListItem.PlayCount,0)</visible>
 					</control>
 				</focusedlayout>
 			</control>


### PR DESCRIPTION
[ Confluence-skin is probably most used in Kodi 17 or lower, so no change is made to those files. ]

2016-12-12 removed infobools

these old deprecated infobools have now been removed:

    StringCompare() (use String.IsEqual instead)
    SubString() (use String.Contains instead)
    IntegerGreaterThan() (use Integer.IsGreater instead)
    IsEmpty() (use String.IsEmpty instead)

pull-request: 11058 (PR)
commit: [https://github.com/xbmc/xbmc/commit/5415...1ace7f3f42](https://github.com/xbmc/xbmc/commit/5415...1ace7f3f42)