### PR TITLE
isEmpty replaced with String.IsEmpty

### DIFF
--- a/estuaryupdate.py
+++ b/estuaryupdate.py
@@ -124,7 +124,7 @@ class EstuaryUpdate():
 \t\t\t\t\t\t<param name="label" value="$ADDON[script.videoextras 32001]" />
 \t\t\t\t\t\t<param name="onclick_1" value="Action(close)" />
 \t\t\t\t\t\t<param name="onclick_2" value="RunScript(script.videoextras,display,$INFO[ListItem.FilenameAndPath])" />
-\t\t\t\t\t\t<param name="visible" value="System.HasAddon(script.videoextras) + [String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,episode)] + IsEmpty(Window(movieinformation).Property(HideVideoExtrasButton))" />'''
+\t\t\t\t\t\t<param name="visible" value="System.HasAddon(script.videoextras) + [String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,episode)] + String.IsEmpty(Window(movieinformation).Property(HideVideoExtrasButton))" />'''
 
         insertTxt = previousButton + (DIALOG_VIDEO_INFO_BUTTON % idval)
         dialogXmlStr = dialogXmlStr.replace(previousButton, insertTxt)


### PR DESCRIPTION
[ Confluence-skin is probably most used in Kodi 17 or lower, so no change is made to those files. ]

2016-12-12 removed infobools

these old deprecated infobools have now been removed:

    StringCompare() (use String.IsEqual instead)
    SubString() (use String.Contains instead)
    IntegerGreaterThan() (use Integer.IsGreater instead)
    IsEmpty() (use String.IsEmpty instead)

pull-request: 11058 (PR)
commit: [https://github.com/xbmc/xbmc/commit/5415...1ace7f3f42](https://github.com/xbmc/xbmc/commit/5415...1ace7f3f42)