### PR TITLE
Update to skin configuration

### DIFF
--- a/confupdate.py
+++ b/confupdate.py
@@ -175,8 +175,7 @@ class ConfUpdate():
 \t\t\t\t\t\t<include>ButtonInfoDialogsCommonValues</include>
 \t\t\t\t\t\t<label>$ADDON[script.videoextras 32001]</label>
 \t\t\t\t\t\t<onclick>RunScript(script.videoextras,display,"$INFO[ListItem.FilenameAndPath]")</onclick>
-\t\t\t\t\t\t<visible>System.HasAddon(script.videoextras) + [Container.Content(movies) | Container.Content(episodes) | Container.Content(TVShows) | Container.Content(musicvideos)] + IsEmpty(Window(movieinformation).Property("HideVideoExtrasButton"))</visible>'''
-
+\t\t\t\t\t\t<visible>System.HasAddon(script.videoextras) + [Container.Content(movies) | Container.Content(episodes) | Container.Content(TVShows) | Container.Content(musicvideos)] + String.IsEmpty(Window(movieinformation).Property("HideVideoExtrasButton"))</visible>'''
         insertTxt = previousButton + (DIALOG_VIDEO_INFO_BUTTON % idval)
         dialogXmlStr = dialogXmlStr.replace(previousButton, insertTxt)
 

--- a/estuaryupdate.py
+++ b/estuaryupdate.py
@@ -99,7 +99,7 @@ class EstuaryUpdate():
         dialogXmlStr = dialogXmlStr.replace(previousOnLoad, insertTxt)
 
         # Now we need to add the button after the Final button
-        previousButton = '<param name="label" value="$LOCALIZE[208]" />'
+        previousButton = '<param name="label" value="$VAR[VideoInfoPlayButtonLabelVar]" />'
 
         if previousButton not in dialogXmlStr:
             # The file has had a standard component deleted, so quit

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,7 +5,7 @@
 		<setting id="searchNested" type="bool" label="32003" default="true"/>
 		<setting id="enableFileTag" type="bool" label="32004" default="false"/>
 		<setting id="extrasFileTag" subsetting="true" enable="eq(-1,true)" type="text" label="32005" default="-extras-"/>
-		<setting id="detailedList" type="bool" label="32025" default="true"/>
+		<setting id="detailedList" type="bool" label="32025" default="false"/>
 		<setting id="extrasReturn" visible="eq(-1,false)" type="labelenum" label="32006" lvalues="32007|32008|32001|32009" default="32007" />
 		<setting id="detailedReturn" visible="eq(-2,true)" type="labelenum" label="32026" lvalues="32007|32008|32009" default="32007" />
 		<setting id="showExtrasAfterMovie" type="bool" label="32038" default="false"/>


### PR DESCRIPTION
Hi malvinas2. You did a nice job updating the script, but I think I can make some nice additions to it.
I modified the script to make automatic changes on both confluence skin and estuary skin. They both work now on Leia, by adding the "Extras" button to video dialog just like it was on Krypton.

Unfortunately, we never saw an icon overlay indicating extras on Estuary skin (like it does on Confluence) and it stays that way.

I also changed the default setting to disable detailed list, until we figure out a way to make it work again (I'm assuming it doesn't work on titan too).

Anyway, I'm sharing what I did with you because your fork seems to be the most complete.